### PR TITLE
feat: implement caip-19 asset type and id parsing

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -29,6 +29,7 @@ export class AccountID {
     if (typeof params === "string") {
       params = AccountID.parse(params);
     }
+
     this.chainId = new ChainID(params.chainId);
     this.address = params.address;
   }

--- a/src/assetId.ts
+++ b/src/assetId.ts
@@ -1,0 +1,57 @@
+import {
+  AssetNamespaceAndReference,
+  AssetNamespaceAndReferenceParams,
+} from "./assetNamespaceAndReference";
+import { ChainID, ChainIDParams } from "./chain";
+import { CAIP } from "./spec";
+import { IdentifierSpec } from "./types";
+import { isValidId, joinParams, getParams } from "./utils";
+
+export interface AssetIdParams {
+  chainId: string | ChainIDParams;
+  assetNamespaceAndReference: string | AssetNamespaceAndReferenceParams;
+  tokenId: string;
+}
+
+export class AssetId {
+  public static spec: IdentifierSpec = CAIP["19"].assetId;
+
+  public static parse(id: string): AssetIdParams {
+    if (!isValidId(id, this.spec)) {
+      throw new Error(`Invalid ${this.spec.name} provided: ${id}`);
+    }
+    return new AssetId(getParams<AssetIdParams>(id, this.spec)).toJson();
+  }
+
+  public static format(params: AssetIdParams): string {
+    return joinParams(params as any, this.spec);
+  }
+
+  public chainId: ChainID;
+  public assetNamespaceAndReference: AssetNamespaceAndReference;
+  public tokenId: string;
+
+  constructor(params: AssetIdParams | string) {
+    if (typeof params === "string") {
+      params = AssetId.parse(params);
+    }
+
+    this.chainId = new ChainID(params.chainId);
+    this.assetNamespaceAndReference = new AssetNamespaceAndReference(
+      params.assetNamespaceAndReference
+    );
+    this.tokenId = params.tokenId;
+  }
+
+  public toString(): string {
+    return AssetId.format(this.toJson());
+  }
+
+  public toJson(): AssetIdParams {
+    return {
+      chainId: this.chainId.toJson(),
+      assetNamespaceAndReference: this.assetNamespaceAndReference.toJson(),
+      tokenId: this.tokenId,
+    };
+  }
+}

--- a/src/assetNamespaceAndReference.ts
+++ b/src/assetNamespaceAndReference.ts
@@ -1,0 +1,48 @@
+import { CAIP } from "./spec";
+import { IdentifierSpec } from "./types";
+import { isValidId, joinParams, getParams } from "./utils";
+
+export interface AssetNamespaceAndReferenceParams {
+  assetNamespace: string;
+  assetReference: string;
+}
+
+export class AssetNamespaceAndReference {
+  public static spec: IdentifierSpec = CAIP["19"].assetNamespaceAndReference;
+
+  public static parse(id: string): AssetNamespaceAndReferenceParams {
+    if (!isValidId(id, this.spec)) {
+      throw new Error(`Invalid ${this.spec.name} provided: ${id}`);
+    }
+    return new AssetNamespaceAndReference(
+      getParams<AssetNamespaceAndReferenceParams>(id, this.spec)
+    ).toJson();
+  }
+
+  public static format(params: AssetNamespaceAndReferenceParams): string {
+    return joinParams(params as any, this.spec);
+  }
+
+  public assetNamespace: string;
+  public assetReference: string;
+
+  constructor(params: AssetNamespaceAndReferenceParams | string) {
+    if (typeof params === "string") {
+      params = AssetNamespaceAndReference.parse(params);
+    }
+
+    this.assetNamespace = params.assetNamespace;
+    this.assetReference = params.assetReference;
+  }
+
+  public toString(): string {
+    return AssetNamespaceAndReference.format(this.toJson());
+  }
+
+  public toJson(): AssetNamespaceAndReferenceParams {
+    return {
+      assetNamespace: this.assetNamespace,
+      assetReference: this.assetReference,
+    };
+  }
+}

--- a/src/assetType.ts
+++ b/src/assetType.ts
@@ -1,0 +1,53 @@
+import {
+  AssetNamespaceAndReference,
+  AssetNamespaceAndReferenceParams,
+} from "./assetNamespaceAndReference";
+import { ChainID, ChainIDParams } from "./chain";
+import { CAIP } from "./spec";
+import { IdentifierSpec } from "./types";
+import { isValidId, joinParams, getParams } from "./utils";
+
+export interface AssetTypeParams {
+  chainId: string | ChainIDParams;
+  assetNamespaceAndReference: string | AssetNamespaceAndReferenceParams;
+}
+
+export class AssetType {
+  public static spec: IdentifierSpec = CAIP["19"].assetType;
+
+  public static parse(id: string): AssetTypeParams {
+    if (!isValidId(id, this.spec)) {
+      throw new Error(`Invalid ${this.spec.name} provided: ${id}`);
+    }
+    return new AssetType(getParams<AssetTypeParams>(id, this.spec)).toJson();
+  }
+
+  public static format(params: AssetTypeParams): string {
+    return joinParams(params as any, this.spec);
+  }
+
+  public chainId: ChainID;
+  public assetNamespaceAndReference: AssetNamespaceAndReference;
+
+  constructor(params: AssetTypeParams | string) {
+    if (typeof params === "string") {
+      params = AssetType.parse(params);
+    }
+
+    this.chainId = new ChainID(params.chainId);
+    this.assetNamespaceAndReference = new AssetNamespaceAndReference(
+      params.assetNamespaceAndReference
+    );
+  }
+
+  public toString(): string {
+    return AssetType.format(this.toJson());
+  }
+
+  public toJson(): AssetTypeParams {
+    return {
+      chainId: this.chainId.toJson(),
+      assetNamespaceAndReference: this.assetNamespaceAndReference,
+    };
+  }
+}

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -28,6 +28,7 @@ export class ChainID {
     if (typeof params === "string") {
       params = ChainID.parse(params);
     }
+
     this.namespace = params.namespace;
     this.reference = params.reference;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./account";
 export * from "./chain";
+export * from "./assetType";
+export * from "./assetId";

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -33,7 +33,59 @@ const CAIP10: IdentifierSpec = {
   },
 };
 
+// represents namespace:reference in CAIP-19
+const AssetNamespaceAndReference: IdentifierSpec = {
+  name: "assetNamespaceAndReference",
+  regex: "[-:a-zA-Z0-9]{5,128}",
+  parameters: {
+    delimiter: ":",
+    values: {
+      0: {
+        name: "assetNamespace",
+        regex: "[-a-z0-9]{3,16}",
+      },
+      1: {
+        name: "assetReference",
+        regex: "[-a-zA-Z0-9]{1,47}",
+      },
+    },
+  },
+};
+
+const CAIP19AssetType: IdentifierSpec = {
+  name: "assetType",
+  regex: "[-:a-zA-Z0-9]{7,128}",
+  parameters: {
+    delimiter: "/",
+    values: {
+      0: CAIP2,
+      1: AssetNamespaceAndReference,
+    },
+  },
+};
+
+const CAIP19AssetId: IdentifierSpec = {
+  name: "assetId",
+  regex: "[-:a-zA-Z0-9]{7,128}",
+  parameters: {
+    delimiter: "/",
+    values: {
+      0: CAIP2,
+      1: AssetNamespaceAndReference,
+      2: {
+        name: "tokenId",
+        regex: "[-a-zA-Z0-9]{1,47}",
+      },
+    },
+  },
+};
+
 export const CAIP = {
   "2": CAIP2,
   "10": CAIP10,
+  "19": {
+    assetNamespaceAndReference: AssetNamespaceAndReference,
+    assetType: CAIP19AssetType,
+    assetId: CAIP19AssetId,
+  },
 };

--- a/test/assetId.test.ts
+++ b/test/assetId.test.ts
@@ -1,0 +1,40 @@
+import { AssetId } from "../src";
+
+import * as data from "./data";
+
+function assertInterface(result: AssetId) {
+  expect(result.chainId.toString()).toEqual(data.CHAIN_ID_STRING);
+  expect(result.assetNamespaceAndReference.toString()).toEqual(
+    data.ASSET_NAMESPACE_AND_REFERENCE_STRING
+  );
+  expect(result.tokenId).toEqual(data.TOKEN_ID);
+  expect(result.toString()).toEqual(data.ASSET_ID_STRING);
+  expect(result.toJson()).toEqual(data.ASSET_ID_NESTED_PARAMS);
+}
+
+describe("AssetId", () => {
+  it("should parse string", async () => {
+    const result = AssetId.parse(data.ASSET_ID_STRING);
+    expect(result).toEqual(data.ASSET_ID_NESTED_PARAMS);
+  });
+
+  it("should format params", async () => {
+    const result = AssetId.format(data.ASSET_ID_PARAMS);
+    expect(result).toEqual(data.ASSET_ID_STRING);
+  });
+
+  it("should instantiate from params", async () => {
+    const result = new AssetId(data.ASSET_ID_PARAMS);
+    assertInterface(result);
+  });
+
+  it("should instantiate from string", async () => {
+    const result = new AssetId(data.ASSET_ID_STRING);
+    assertInterface(result);
+  });
+
+  it("should instantiate from nested params", async () => {
+    const result = new AssetId(data.ASSET_ID_NESTED_PARAMS);
+    assertInterface(result);
+  });
+});

--- a/test/assetNamespaceAndReference.test.ts
+++ b/test/assetNamespaceAndReference.test.ts
@@ -1,0 +1,47 @@
+import { AssetNamespaceAndReference } from "../src/assetNamespaceAndReference";
+
+import * as data from "./data";
+
+function assertInterface(result: AssetNamespaceAndReference) {
+  expect(result.assetNamespace).toEqual(data.ASSET_NAMESPACE);
+  expect(result.assetReference).toEqual(data.ASSET_REFERENCE);
+  expect(result.toString()).toEqual(data.ASSET_NAMESPACE_AND_REFERENCE_STRING);
+  expect(result.toJson()).toEqual(data.ASSET_NAMESPACE_AND_REFERENCE_PARAMS);
+}
+
+describe("AssetNamespaceAndReference", () => {
+  it("should parse string", async () => {
+    const result = AssetNamespaceAndReference.parse(
+      data.ASSET_NAMESPACE_AND_REFERENCE_STRING
+    );
+    expect(result).toEqual(data.ASSET_NAMESPACE_AND_REFERENCE_PARAMS);
+  });
+
+  it("should format params", async () => {
+    const result = AssetNamespaceAndReference.format(
+      data.ASSET_NAMESPACE_AND_REFERENCE_PARAMS
+    );
+    expect(result).toEqual(data.ASSET_NAMESPACE_AND_REFERENCE_STRING);
+  });
+
+  it("should instantiate from params", async () => {
+    const result = new AssetNamespaceAndReference(
+      data.ASSET_NAMESPACE_AND_REFERENCE_PARAMS
+    );
+    assertInterface(result);
+  });
+
+  it("should instantiate from string", async () => {
+    const result = new AssetNamespaceAndReference(
+      data.ASSET_NAMESPACE_AND_REFERENCE_STRING
+    );
+    assertInterface(result);
+  });
+
+  it("should instantiate from nested params", async () => {
+    const result = new AssetNamespaceAndReference(
+      data.ASSET_NAMESPACE_AND_REFERENCE_PARAMS
+    );
+    assertInterface(result);
+  });
+});

--- a/test/assetType.test.ts
+++ b/test/assetType.test.ts
@@ -1,0 +1,39 @@
+import { AssetType } from "../src";
+
+import * as data from "./data";
+
+function assertInterface(result: AssetType) {
+  expect(result.chainId.toString()).toEqual(data.CHAIN_ID_STRING);
+  expect(result.assetNamespaceAndReference.toString()).toEqual(
+    data.ASSET_NAMESPACE_AND_REFERENCE_STRING
+  );
+  expect(result.toString()).toEqual(data.ASSET_TYPE_STRING);
+  expect(result.toJson()).toEqual(data.ASSET_TYPE_NESTED_PARAMS);
+}
+
+describe("AssetType", () => {
+  it("should parse string", async () => {
+    const result = AssetType.parse(data.ASSET_TYPE_STRING);
+    expect(result).toEqual(data.ASSET_TYPE_NESTED_PARAMS);
+  });
+
+  it("should format params", async () => {
+    const result = AssetType.format(data.ASSET_TYPE_PARAMS);
+    expect(result).toEqual(data.ASSET_TYPE_STRING);
+  });
+
+  it("should instantiate from params", async () => {
+    const result = new AssetType(data.ASSET_TYPE_PARAMS);
+    assertInterface(result);
+  });
+
+  it("should instantiate from string", async () => {
+    const result = new AssetType(data.ASSET_TYPE_STRING);
+    assertInterface(result);
+  });
+
+  it("should instantiate from nested params", async () => {
+    const result = new AssetType(data.ASSET_TYPE_NESTED_PARAMS);
+    assertInterface(result);
+  });
+});

--- a/test/data/index.ts
+++ b/test/data/index.ts
@@ -1,3 +1,6 @@
+import { AssetIdParams, AssetTypeParams } from "../../src";
+import { AssetNamespaceAndReferenceParams } from "../../src/assetNamespaceAndReference";
+
 // ChainID Data Points
 export const CHAIN_ID_DELIMITER = ":";
 export const CHAIN_ID_NAMESPACE = "eip155";
@@ -22,4 +25,41 @@ export const ACCOUNT_ID_PARAMS = {
 export const ACCOUNT_ID_NESTED_PARAMS = {
   chainId: CHAIN_ID_PARAMS,
   address: ACCOUNT_ID_ADDRESS,
+};
+
+// AssetNamespaceAndReference Data Points
+export const ASSET_NAMESPACE_REFERENCE_DELIMITER = ":";
+export const ASSET_NAMESPACE = "namespace";
+export const ASSET_REFERENCE = "0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb";
+export const ASSET_NAMESPACE_AND_REFERENCE_STRING = `${ASSET_NAMESPACE}${ASSET_NAMESPACE_REFERENCE_DELIMITER}${ASSET_REFERENCE}`;
+export const ASSET_NAMESPACE_AND_REFERENCE_PARAMS: AssetNamespaceAndReferenceParams = {
+  assetNamespace: ASSET_NAMESPACE,
+  assetReference: ASSET_REFERENCE,
+};
+
+// AssetType Data Points
+export const ASSET_TYPE_STRING = `${CHAIN_ID_STRING}/${ASSET_NAMESPACE_AND_REFERENCE_STRING}`;
+export const ASSET_TYPE_PARAMS: AssetTypeParams = {
+  chainId: CHAIN_ID_STRING,
+  assetNamespaceAndReference: ASSET_NAMESPACE_AND_REFERENCE_STRING,
+};
+
+export const ASSET_TYPE_NESTED_PARAMS: AssetTypeParams = {
+  chainId: CHAIN_ID_PARAMS,
+  assetNamespaceAndReference: ASSET_NAMESPACE_AND_REFERENCE_PARAMS,
+};
+
+// AssetType Data Points
+export const TOKEN_ID = "1";
+export const ASSET_ID_STRING = `${ASSET_TYPE_STRING}/${TOKEN_ID}`;
+export const ASSET_ID_PARAMS: AssetIdParams = {
+  chainId: CHAIN_ID_STRING,
+  assetNamespaceAndReference: ASSET_NAMESPACE_AND_REFERENCE_STRING,
+  tokenId: TOKEN_ID,
+};
+
+export const ASSET_ID_NESTED_PARAMS: AssetIdParams = {
+  chainId: CHAIN_ID_PARAMS,
+  assetNamespaceAndReference: ASSET_NAMESPACE_AND_REFERENCE_PARAMS,
+  tokenId: TOKEN_ID,
 };


### PR DESCRIPTION
This implements CAIP-19 AssetType and AssetId parsing/formatting following the existing patterns.

What should the `AssetNamespaceAndReference` concept be called? maybe `AssetStore` or `TokenManager` or `TokenStore`, since it's referring to a specific location where assets/tokens are managed/stored? Would follow the `ChainId` pattern, but `AssetId` is already overloaded.

pls double-check my work in the regex values i used for spec.ts — besides the `assetNamespace`, `assetReference`, and `tokenId` since they had clear values from the spec, I guessed at the top level regexes